### PR TITLE
Fix crash in FloatingControlService due to Hilt

### DIFF
--- a/app/src/main/java/com/hereliesaz/et2bruteforce/services/FloatingControlService.kt
+++ b/app/src/main/java/com/hereliesaz/et2bruteforce/services/FloatingControlService.kt
@@ -11,6 +11,7 @@ import android.view.WindowManager
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.*
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
@@ -61,7 +62,8 @@ class FloatingControlService : LifecycleService(), ViewModelStoreOwner, SavedSta
 
     override fun onCreate() {
         super.onCreate()
-        viewModel = ViewModelProvider(this)[BruteforceViewModel::class.java]
+        val factory = (application as HasDefaultViewModelProviderFactory).defaultViewModelProviderFactory
+        viewModel = ViewModelProvider(this, factory)[BruteforceViewModel::class.java]
         savedStateRegistryController.performRestore(null)
         Log.d(TAG, "onCreate")
 


### PR DESCRIPTION
The application was crashing when starting the FloatingControlService because the BruteforceViewModel could not be instantiated.

This was caused by the ViewModelProvider using a default factory that was not Hilt-aware, leading to a `NoSuchMethodException` when trying to create the ViewModel with its injected dependencies.

The fix involves providing the correct Hilt-aware ViewModelProvider.Factory when creating the ViewModelProvider in the service's `onCreate` method. The factory is retrieved from the Application instance, which implements `HasDefaultViewModelProviderFactory`.

## Summary by Sourcery

Provide a Hilt-aware ViewModelProvider.Factory to FloatingControlService to fix a crash instantiating the BruteforceViewModel.

Bug Fixes:
- Resolve a NoSuchMethodException by replacing the default factory that couldn’t inject dependencies into BruteforceViewModel

Enhancements:
- Retrieve and apply the Hilt-aware defaultViewModelProviderFactory from the Application in the service’s onCreate method